### PR TITLE
fix: scheduler response method returns immediately when no requested …

### DIFF
--- a/src/scheduler/Scheduler.java
+++ b/src/scheduler/Scheduler.java
@@ -52,19 +52,16 @@ public class Scheduler implements Runnable {
 		
 		if(messageType == MessageType.ELEVATOR) {
 			synchronized (elevatorMessages) {
-				if (elevatorMessages.isEmpty()) {
-					try {
-						Thread.sleep(5000); // temporary, we don't need this, but useful to debug
-						return null;
-					} catch (Exception e) {
-						// TODO: handle exception
-					}
+				if(!elevatorMessages.isEmpty()) {
+					messages = new LinkedList<Message>(elevatorMessages);
+					elevatorMessages.clear();
 				}
 				
-				messages = new LinkedList<Message>(elevatorMessages);
-				elevatorMessages.clear();
-				
-				elevatorMessages.notifyAll();
+				try {
+					Thread.sleep(5000); // temporary, we don't need this, but useful to debug
+				} catch (Exception e) {
+					// TODO: handle exception
+				}
 			}
 		} else if(messageType == MessageType.FLOOR) {
 			synchronized (floorMessages) {

--- a/src/scheduler/Scheduler.java
+++ b/src/scheduler/Scheduler.java
@@ -52,9 +52,10 @@ public class Scheduler implements Runnable {
 		
 		if(messageType == MessageType.ELEVATOR) {
 			synchronized (elevatorMessages) {
-				while(elevatorMessages.isEmpty()) {
+				if (elevatorMessages.isEmpty()) {
 					try {
-						elevatorMessages.wait();
+						Thread.sleep(5000); // temporary, we don't need this, but useful to debug
+						return null;
 					} catch (Exception e) {
 						// TODO: handle exception
 					}


### PR DESCRIPTION
Instead of making the Elevator (and potentially Floor) system wait while there's no messages from scheduler available, make it so the Scheduler.response() method just returns null when there are no messages.

This way the Elevator system could do it's other work and try to poll for more messages from scheduler again.